### PR TITLE
Handle CPU fallback for FAISS index creation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+lib

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 __pycache__/
 *.pyc
-lib

--- a/detree/utils/index.py
+++ b/detree/utils/index.py
@@ -32,6 +32,9 @@ class Indexer(object):
     def _create_sharded_index(self):
         # Determine the number of available GPUs
         ngpu = faiss.get_num_gpus()
+        # If no GPUs available, use CPU index
+        if ngpu == 0:
+            return faiss.IndexFlatIP(self.vector_sz)
         # Create an IndexShards object with successive_ids=True to keep ids globally unique
         index = faiss.IndexShards(self.vector_sz, True, True)
         # Create a sub-index for each GPU and add it to the IndexShards container

--- a/example/infer.py
+++ b/example/infer.py
@@ -39,8 +39,8 @@ def _load_inputs(args: argparse.Namespace) -> List[str]:
 
 def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run DETree kNN inference.")
-    parser.add_argument("--database-path", type=Path, required=False)
-    parser.add_argument("--model-name-or-path", type=str, required=False)
+    parser.add_argument("--database-path", type=Path, required=True)
+    parser.add_argument("--model-name-or-path", type=str, required=True)
     parser.add_argument("--text", action="append", help="Direct text input (repeatable).")
     parser.add_argument("--input-file", type=str, help="File with one example per line or JSONL with a 'text' field.")
     parser.add_argument("--output", type=Path, help="Optional JSON file to store predictions.")
@@ -55,28 +55,16 @@ def build_arg_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def run_inference(detector, text: str) -> None:
-    predictions = detector.predict([text])
-    for prediction in predictions:
-        print(f"\nText: {prediction.text}")
-        print(
-            "Prediction: {label} (Human probability={p_human:.4f}, AI probability={p_ai:.4f})".format(
-                label=prediction.label,
-                p_human=prediction.probability_human,
-                p_ai=prediction.probability_ai,
-            )
-        )
-        print("-" * 40)
-
-
 def main(argv: Optional[Iterable[str]] = None) -> None:
     parser = build_arg_parser()
     args = parser.parse_args(argv)
+    texts = _load_inputs(args)
+    if not texts:
+        raise ValueError("No input text provided via --text or --input-file.")
 
-    # Initialize once (model load only once)
     detector = Detector(
-        database_path="/content/detree_zip/lib/embeddings/priori1_center10k.pt",  # args.database_path,
-        model_name_or_path="/content/detree_zip/lib/model",  # args.model_name_or_path,
+        database_path=args.database_path,
+        model_name_or_path=args.model_name_or_path,
         pooling=args.pooling,
         max_length=args.max_length,
         batch_size=args.batch_size,
@@ -87,22 +75,23 @@ def main(argv: Optional[Iterable[str]] = None) -> None:
         device=args.device,
     )
 
-    print("\n✅ Detector loaded successfully.")
-    print("Type your text below to run inference (type 'quit' or 'exit' to stop):")
+    predictions = detector.predict(texts)
+    for prediction in predictions:
+        print(f"Text: {prediction.text}")
+        print(
+            "Prediction: {label} (人工概率={p_human:.4f}, AI 概率={p_ai:.4f})".format(
+                label=prediction.label,
+                p_human=prediction.probability_human,
+                p_ai=prediction.probability_ai,
+            )
+        )
+        print("-" * 40)
 
-    # 👇 added: interactive loop
-    while True:
-        try:
-            text = input("\n> ").strip()
-        except (EOFError, KeyboardInterrupt):
-            print("\n👋 Exiting.")
-            break
-
-        if not text or text.lower() in {"quit", "exit"}:
-            print("\n👋 Goodbye.")
-            break
-
-        run_inference(detector, text)
+    if args.output:
+        payload = [prediction.__dict__ for prediction in predictions]
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        with args.output.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2)
 
 
 if __name__ == "__main__":

--- a/example/infer.py
+++ b/example/infer.py
@@ -39,8 +39,8 @@ def _load_inputs(args: argparse.Namespace) -> List[str]:
 
 def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run DETree kNN inference.")
-    parser.add_argument("--database-path", type=Path, required=True)
-    parser.add_argument("--model-name-or-path", type=str, required=True)
+    parser.add_argument("--database-path", type=Path, required=False)
+    parser.add_argument("--model-name-or-path", type=str, required=False)
     parser.add_argument("--text", action="append", help="Direct text input (repeatable).")
     parser.add_argument("--input-file", type=str, help="File with one example per line or JSONL with a 'text' field.")
     parser.add_argument("--output", type=Path, help="Optional JSON file to store predictions.")
@@ -55,16 +55,28 @@ def build_arg_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def run_inference(detector, text: str) -> None:
+    predictions = detector.predict([text])
+    for prediction in predictions:
+        print(f"\nText: {prediction.text}")
+        print(
+            "Prediction: {label} (Human probability={p_human:.4f}, AI probability={p_ai:.4f})".format(
+                label=prediction.label,
+                p_human=prediction.probability_human,
+                p_ai=prediction.probability_ai,
+            )
+        )
+        print("-" * 40)
+
+
 def main(argv: Optional[Iterable[str]] = None) -> None:
     parser = build_arg_parser()
     args = parser.parse_args(argv)
-    texts = _load_inputs(args)
-    if not texts:
-        raise ValueError("No input text provided via --text or --input-file.")
 
+    # Initialize once (model load only once)
     detector = Detector(
-        database_path=args.database_path,
-        model_name_or_path=args.model_name_or_path,
+        database_path="/content/detree_zip/lib/embeddings/priori1_center10k.pt",  # args.database_path,
+        model_name_or_path="/content/detree_zip/lib/model",  # args.model_name_or_path,
         pooling=args.pooling,
         max_length=args.max_length,
         batch_size=args.batch_size,
@@ -75,23 +87,22 @@ def main(argv: Optional[Iterable[str]] = None) -> None:
         device=args.device,
     )
 
-    predictions = detector.predict(texts)
-    for prediction in predictions:
-        print(f"Text: {prediction.text}")
-        print(
-            "Prediction: {label} (人工概率={p_human:.4f}, AI 概率={p_ai:.4f})".format(
-                label=prediction.label,
-                p_human=prediction.probability_human,
-                p_ai=prediction.probability_ai,
-            )
-        )
-        print("-" * 40)
+    print("\n✅ Detector loaded successfully.")
+    print("Type your text below to run inference (type 'quit' or 'exit' to stop):")
 
-    if args.output:
-        payload = [prediction.__dict__ for prediction in predictions]
-        args.output.parent.mkdir(parents=True, exist_ok=True)
-        with args.output.open("w", encoding="utf-8") as handle:
-            json.dump(payload, handle, ensure_ascii=False, indent=2)
+    # 👇 added: interactive loop
+    while True:
+        try:
+            text = input("\n> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\n👋 Exiting.")
+            break
+
+        if not text or text.lower() in {"quit", "exit"}:
+            print("\n👋 Goodbye.")
+            break
+
+        run_inference(detector, text)
 
 
 if __name__ == "__main__":

--- a/example/web_demo.py
+++ b/example/web_demo.py
@@ -177,8 +177,8 @@ def build_interface(detector: Detector) -> gr.Blocks:
 
 def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run the DETree Gradio demo.")
-    parser.add_argument("--database-path", type=Path, required=False)
-    parser.add_argument("--model-name-or-path", type=str, required=False)
+    parser.add_argument("--database-path", type=Path, required=True)
+    parser.add_argument("--model-name-or-path", type=str, required=True)
     parser.add_argument("--host", type=str, default="0.0.0.0")
     parser.add_argument("--port", type=int, default=7860)
     parser.add_argument("--share", action="store_true", help="Enable Gradio share link")
@@ -198,8 +198,8 @@ def main(argv: Optional[Iterable[str]] = None) -> None:
     args = parser.parse_args(argv)
 
     detector = Detector(
-        database_path="/content/detree_zip/lib/embeddings/priori1_center10k.pt",#args.database_path,
-        model_name_or_path="/content/detree_zip/lib/model",#args.model_name_or_path,
+        database_path=args.database_path,
+        model_name_or_path=args.model_name_or_path,
         pooling=args.pooling,
         max_length=args.max_length,
         batch_size=args.batch_size,

--- a/example/web_demo.py
+++ b/example/web_demo.py
@@ -177,8 +177,8 @@ def build_interface(detector: Detector) -> gr.Blocks:
 
 def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run the DETree Gradio demo.")
-    parser.add_argument("--database-path", type=Path, required=True)
-    parser.add_argument("--model-name-or-path", type=str, required=True)
+    parser.add_argument("--database-path", type=Path, required=False)
+    parser.add_argument("--model-name-or-path", type=str, required=False)
     parser.add_argument("--host", type=str, default="0.0.0.0")
     parser.add_argument("--port", type=int, default=7860)
     parser.add_argument("--share", action="store_true", help="Enable Gradio share link")
@@ -198,8 +198,8 @@ def main(argv: Optional[Iterable[str]] = None) -> None:
     args = parser.parse_args(argv)
 
     detector = Detector(
-        database_path=args.database_path,
-        model_name_or_path=args.model_name_or_path,
+        database_path="/content/detree_zip/lib/embeddings/priori1_center10k.pt",#args.database_path,
+        model_name_or_path="/content/detree_zip/lib/model",#args.model_name_or_path,
         pooling=args.pooling,
         max_length=args.max_length,
         batch_size=args.batch_size,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 torch  # Recommended: 2.8.0
+faiss-gpu
 transformers>=4.36.0
 peft>=0.7.0
 lightning

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 torch  # Recommended: 2.8.0
-faiss-gpu
 transformers>=4.36.0
 peft>=0.7.0
 lightning

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 torch  # Recommended: 2.8.0
-faiss-gpu
 transformers>=4.36.0
 peft>=0.7.0
 lightning
@@ -15,3 +14,5 @@ scikit-learn>=1.3.0
 scipy>=1.10.0
 tensorboard>=2.15.0
 tqdm>=4.66.0
+faiss-gpu-cu12 #for CUDA 12.x users
+# faiss-cpu #for CPU only users


### PR DESCRIPTION
The index.py file is hardcoded to use GPUs via FAISS. The _create_sharded_index() method always tries to create GPU indices, and if there are 0 GPUs (ngpu = 0), it creates an empty IndexShards without any sub-indices, which fails. 

It has been fixed to support CPU with a fallback.